### PR TITLE
Fix import in inference example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To make predictions on images or videos using the marine detection models, follo
 2. **Prediction Functions**: Utilize the following Python functions to generate predictions with bounding box annotations.
 
 ```python
-from marine_detect.predict import predict_on_images, predict_on_video
+from src.marine_detect.predict import predict_on_images, predict_on_video
 
 # Predict on a set of images using FishInv and MegaFauna models
 predict_on_images(


### PR DESCRIPTION
Adjust import statement in example inference code to include src directory:

```python
from marine_detect.predict import predict_on_images, predict_on_video
```

```shell
ModuleNotFoundError: No module named 'marine_detect'
```

New import:
```python
from src.marine_detect.predict import predict_on_images, predict_on_video
```